### PR TITLE
Support blackholing of requests

### DIFF
--- a/evldns.h
+++ b/evldns.h
@@ -76,6 +76,7 @@ struct evldns_server_request {
 	/* misc flags */
 	uint8_t						 wire_resphead:2;
 	uint8_t						 is_tcp:1;
+	uint8_t						 blackhole:1;
 
 	/* pending requests for UDP mode */
 	TAILQ_ENTRY(evldns_server_request) next;


### PR DESCRIPTION
This patch adds a 'blackhole' flag to evldns_server_request. If a
callback in the callback chain sets this flag, processing of the
callback chain will be aborted and the request will be "blackholed".

A blackholed UDP request is dropped on the floor by the server.  No
response is sent to the client.

A blackholed TCP connection is immediately closed by the server.
