### PR TITLE
Fix a per-request leak in the UDP error handling path

### DIFF
--- a/evldns.c
+++ b/evldns.c
@@ -502,6 +502,8 @@ evldns_udp_read_callback(evldns_server_port *port)
 
 		if (server_process_packet(req) >= 0) {
 			evldns_server_udp_write_queue(req);
+		} else {
+			server_request_free(req);
 		}
 	}
 }


### PR DESCRIPTION
In the UDP path, 'evldns_server_request' objects are allocated in the
processing loop in evldns_udp_read_callback(), and deallocated in
evldns_server_udp_write_queue(), after the socket write succeeds.

However, evldns_server_udp_write_queue() will only be called if
server_process_packet() succeeds, which is not guaranteed; there are
several error returns that result in a response packet not being
generated, so there is no socket write to perform.

This results in a per-packet memory leak. E.g., this output from
valgrind after sending a dozen UDP packets that fail the ldns_wire2pkt()
check in server_process_packet():

==20693== 789,300 (2,880 direct, 786,420 indirect) bytes in 12 blocks are definitely lost in loss record 23 of 23
==20693==    at 0x4C2AD10: calloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==20693==    by 0x403854: evldns_udp_read_callback (evldns.c:474)
==20693==    by 0x403854: evldns_udp_callback (evldns.c:411)
==20693==    by 0x50A43DB: event_base_loop (in /usr/lib/x86_64-linux-gnu/libevent-2.0.so.5.1.9)

This patch adds a call to server_request_free() in
evldns_udp_read_callback() in the event that server_process_packet()
fails.
